### PR TITLE
トランザクションを開始した時

### DIFF
--- a/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
+++ b/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
@@ -199,7 +199,19 @@ module ActiveRecord
           super
         end
       end
-      
+
+      def create_savepoint(name = current_savepoint_name)
+        master_connection.create_savepoint(name)
+      end
+
+      def rollback_to_savepoint(name = current_savepoint_name)
+        master_connection.rollback_to_savepoint(name)
+      end
+
+      def release_savepoint(name = current_savepoint_name)
+        master_connection.release_savepoint(name)
+      end
+
       def visitor=(visitor)
         all_connections.each{|conn| conn.visitor = visitor}
       end


### PR DESCRIPTION
ActiveRecord::Base.connection(ActiveRecord::ConnectionAdapters::SeamlessDatabasePoolAdapter::Mysql2)
の @transaction は RealTransaction になるが
ActiveRecord::Base.connection.master_connection(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
の @transaction は ClosedTransaction のままになる。
current_savepoint_name は後者ではなく前者をレシーバとしてコールしなければならなかった。

次のようなネストしたものが動いていませんでした。

```
ActiveRecord::Base.transaction do
  Age.create!(name: 'a', reading: 'a', min: 0, max: 0, roman: 'a')
  ActiveRecord::Base.transaction(requires_new: !Rails.env.test?) do
    Age.create!(name: 'b', reading: 'b', min: 1, max: 1, roman: 'b')
    ActiveRecord::Base.transaction(requires_new: !Rails.env.test?) do
      Age.create!(name: 'c', reading: 'c', min: 2, max: 2, roman: 'c')
    end
  end
  raise 'a'
end
```

> test 環境では次のエラーで requires_new: true が動かない
> Mysql2::Error: SAVEPOINT active_record_0 does not exist: ROLLBACK TO SAVEPOINT 

この件もこれで解決されます。

よろしくお願いします。
